### PR TITLE
fix: exit control handler loop when mpsc channel closes

### DIFF
--- a/claude-code-sdk-rs/src/internal_query.rs
+++ b/claude-code-sdk-rs/src/internal_query.rs
@@ -324,8 +324,13 @@ impl Query {
                     // Receive control request without holding lock
                     let control_message = control_rx.recv().await;
 
-                    if let Some(control_message) = control_message {
-                        debug!("Received control message: {:?}", control_message);
+                    // If channel closed (sender dropped), exit the loop
+                    let Some(control_message) = control_message else {
+                        debug!("Control channel closed, exiting control handler");
+                        break;
+                    };
+
+                    debug!("Received control message: {:?}", control_message);
 
                         // Check if this is a control response (from CLI to SDK)
                         if control_message.get("type").and_then(|v| v.as_str()) == Some("control_response") {
@@ -668,7 +673,6 @@ impl Query {
                                 }
                             }
                         }
-                    }
                 }
             });
         }


### PR DESCRIPTION
## Summary
- When a Claude session ends, the control channel sender is dropped, causing `recv()` to return `None`
- Previously the loop continued indefinitely, spinning at 100% CPU
- Now properly breaks out of the loop when the channel closes

## Problem
The control handler in `start_control_handler` uses an mpsc channel to receive control messages. When the session ends and the sender is dropped, `control_rx.recv().await` returns `None`. The old code used `if let Some(...)` which just skipped the body and continued looping infinitely:

```rust
// Before (bug)
if let Some(control_message) = control_message {
    // handle message
}
// When recv() returns None, loop continues spinning!
```

## Solution
Changed to `let Some(...) else { break }` pattern to properly exit:

```rust
// After (fix)
let Some(control_message) = control_message else {
    debug!("Control channel closed, exiting control handler");
    break;
};
```

## Testing
- Observed CPU drop from 134% to ~2% after applying this fix
- Verified with `perf` profiling that the spinning loop was the source