### PR TITLE
feat(cc-sdk): add explicit session_id support to ClaudeCodeOptions

### DIFF
--- a/claude-code-sdk-rs/src/client.rs
+++ b/claude-code-sdk-rs/src/client.rs
@@ -276,7 +276,23 @@ impl ClaudeSDKClient {
     }
 
     /// Send a user message to Claude
+    ///
+    /// Uses the session ID from `ClaudeCodeOptions::session_id` if set,
+    /// otherwise falls back to "default".
     pub async fn send_user_message(&mut self, prompt: String) -> Result<()> {
+        let session_id = self
+            .options
+            .session_id
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
+        self.send_user_message_with_session(prompt, session_id).await
+    }
+
+    async fn send_user_message_with_session(
+        &mut self,
+        prompt: String,
+        session_id: String,
+    ) -> Result<()> {
         // Check connection
         {
             let state = self.state.read().await;
@@ -286,9 +302,6 @@ impl ClaudeSDKClient {
                 });
             }
         }
-
-        // Use default session ID
-        let session_id = "default".to_string();
 
         // Update session data
         {
@@ -316,14 +329,18 @@ impl ClaudeSDKClient {
         Ok(())
     }
 
-    /// Send a request to Claude (alias for send_user_message with optional session_id)
+    /// Send a request to Claude with an optional explicit session ID
+    ///
+    /// Priority: explicit `session_id` argument > `ClaudeCodeOptions::session_id` > "default"
     pub async fn send_request(
         &mut self,
         prompt: String,
-        _session_id: Option<String>,
+        session_id: Option<String>,
     ) -> Result<()> {
-        // For now, ignore session_id and use send_user_message
-        self.send_user_message(prompt).await
+        let effective_session_id = session_id
+            .or_else(|| self.options.session_id.clone())
+            .unwrap_or_else(|| "default".to_string());
+        self.send_user_message_with_session(prompt, effective_session_id).await
     }
 
     /// Receive messages from Claude
@@ -988,5 +1005,19 @@ mod tests {
             client.query_handler.is_some(),
             "enable_file_checkpointing should initialize the query handler for control protocol requests"
         );
+    }
+
+    #[test]
+    fn test_session_id_option_defaults_to_none() {
+        let options = ClaudeCodeOptions::default();
+        assert!(options.session_id.is_none());
+    }
+
+    #[test]
+    fn test_session_id_builder() {
+        let options = ClaudeCodeOptions::builder()
+            .session_id("my-session-123")
+            .build();
+        assert_eq!(options.session_id.as_deref(), Some("my-session-123"));
     }
 }

--- a/claude-code-sdk-rs/src/types.rs
+++ b/claude-code-sdk-rs/src/types.rs
@@ -1416,6 +1416,14 @@ pub struct ClaudeCodeOptions {
     /// Thinking configuration (replaces max_thinking_tokens)
     /// When set, takes priority over max_thinking_tokens
     pub thinking: Option<ThinkingConfig>,
+    /// Session ID to use for conversations
+    ///
+    /// When set, this ID is used instead of the default "default" session identifier.
+    /// This allows callers to control the session identity, which is important for
+    /// resume/fork workflows and for aligning session IDs across different layers.
+    ///
+    /// If not set, falls back to "default" (preserving backward compatibility).
+    pub session_id: Option<String>,
 }
 
 impl std::fmt::Debug for ClaudeCodeOptions {
@@ -1448,6 +1456,7 @@ impl std::fmt::Debug for ClaudeCodeOptions {
             .field("control_protocol_format", &self.control_protocol_format)
             .field("effort", &self.effort)
             .field("thinking", &self.thinking)
+            .field("session_id", &self.session_id)
             .finish()
     }
 }
@@ -1584,6 +1593,16 @@ impl ClaudeCodeOptionsBuilder {
     /// Set resume conversation ID
     pub fn resume(mut self, id: impl Into<String>) -> Self {
         self.options.resume = Some(id.into());
+        self
+    }
+
+    /// Set session ID for conversations
+    ///
+    /// When set, this ID is used instead of the default "default" session identifier.
+    /// This allows callers to control the session identity used in messages sent to
+    /// Claude Code CLI.
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.options.session_id = Some(id.into());
         self
     }
 


### PR DESCRIPTION
## Summary

Currently `send_user_message()` hardcodes `"default"` as the session identifier, and `send_request()` ignores the caller-provided `session_id` parameter. This makes it impossible for callers to control session identity, which is needed for:

- **Resume/fork workflows**: callers need to use the canonical Claude session ID, not a hardcoded placeholder
- **Multi-layer session alignment**: applications wrapping cc-sdk need their own session IDs to match what's sent to Claude Code CLI
- **Parity with the TypeScript SDK**: [`claude-agent-acp`](https://github.com/agentclientprotocol/claude-agent-acp) passes `options.sessionId` through to Claude, giving callers full control

## Real-world use case: Acepe

[Acepe](https://github.com/flazouh/acepe) is an open-source agent-first IDE built with Tauri + Svelte that uses `cc-sdk` to integrate Claude Code as one of its agent providers.

Acepe generates its own session UUIDs to track conversations across its UI, database, and streaming logs. The problem is that `cc-sdk` ignores this ID and hardcodes `"default"` internally, so:

1. **Streaming logs are confusing** — Acepe writes log files keyed by its session ID (`3525314b-...`), but the raw inbound messages from Claude contain a different provider session ID (`b343a77c-...`). Debugging requires mentally mapping between two unrelated identifiers.

2. **Resume/fork is broken** — When Acepe calls `builder.resume(session_id)`, it passes its own UUID, but Claude CLI doesn't recognize it because the original session was created under a different (internal) ID. The session can't be resumed.

3. **Session identity is split** — Acepe's permission handler, UI event dispatcher, and tool call tracker all reference the Acepe session ID, but the cc-sdk subprocess uses `"default"`. There's no single source of truth.

With this PR, Acepe can do:

```rust
let options = ClaudeCodeOptions::builder()
    .cwd(project_path)
    .session_id(acepe_session_id)  // now honored by the SDK
    .build();
```

This aligns the session identity across all layers — Acepe UI, cc-sdk transport, and Claude CLI — from the moment the session is created.

Acepe has already shipped this fix using a `[patch.crates-io]` override pointing to this branch: [flazouh/acepe#16](https://github.com/flazouh/acepe/pull/16).

## Changes

- Add `session_id: Option<String>` field to `ClaudeCodeOptions`
- Add `session_id()` builder method on `ClaudeCodeOptionsBuilder`
- Add `session_id` to the `Debug` impl
- `send_user_message()` now uses `options.session_id` when set, falls back to `"default"`
- `send_request()` now honors the explicit `session_id` argument, falls back to `options.session_id`, then to `"default"`
- Extract `send_user_message_with_session()` private helper to share logic
- Add unit tests for the new option and builder method

## Backward compatibility

Fully backward compatible:
- `session_id` defaults to `None`, preserving existing `"default"` behavior
- `send_request(prompt, None)` behaves identically to before unless `options.session_id` is set
- No breaking API changes

## Test plan

- [x] `cargo test -p cc-sdk session_id` — 3 tests pass
- [x] Full `cargo test -p cc-sdk` — all 184 tests pass
- [x] End-to-end in Acepe: streaming logs show unified session IDs, merged to main via [flazouh/acepe#16](https://github.com/flazouh/acepe/pull/16)
- [ ] Integration test with a real Claude Code CLI session using explicit session ID